### PR TITLE
Convert markdown link to html

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,7 +72,7 @@ while each active project work is housed in their repository on </span><strong><
 We help each other track down datasets, refine models, improve visualizations, team up on apps, debug code, promote work, and connect with communities who need our analysis.</span></p>
 
 <p style="text-align:left"><br>
-<span style="font-size:1.0em">In the footsteps of [similar organizations](https://github.com/DataForGood-Norway/read-this-first/blob/master/README.md#similar-organizations), we are working to develop a cohesive structure to better support volunteers in learning, working, and leading projects while remaining committed to our mission of producing data projects that have a positive and tangible impact on the world.</span><br>
+<span style="font-size:1.0em">In the footsteps of <a href="https://github.com/DataForGood-Norway/read-this-first/blob/master/README.md#similar-organizations">similar organizations</a>, we are working to develop a cohesive structure to better support volunteers in learning, working, and leading projects while remaining committed to our mission of producing data projects that have a positive and tangible impact on the world.</span><br>
  </p>
 
 


### PR DESCRIPTION
There seems to be a link left in Markdown format on the last page. I am not sure if this page is generated from somewhere or if this actually is the correct place to fix? :)